### PR TITLE
ace: error on CONFIG_SYS_HEAP_RUNTIME_STATS=y

### DIFF
--- a/subsys/ace/osal/osal_alloc.c
+++ b/subsys/ace/osal/osal_alloc.c
@@ -19,7 +19,7 @@ K_HEAP_DEFINE(sid_heap, CONFIG_SIDEWALK_HEAP_SIZE);
 
 static void heap_alloc_stats(struct sys_heap *p_heap, size_t mem_to_alloc)
 {
-	struct sys_heap_runtime_stats stat;
+	struct sys_memory_stats stat;
 
 	sys_heap_runtime_stats_get(p_heap, &stat);
 	if (mem_to_alloc > stat.free_bytes) {


### PR DESCRIPTION
Fix a build error when this flag is enabled: the structure name changed
in Zephyr 3.2:

```log
..ace/osal/osal_alloc.c:22:39: error: storage size of 'stat' isn't known
   22 |         struct sys_heap_runtime_stats stat;
      |                                       ^~~~

```

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
